### PR TITLE
Filterable table jQuery plugin

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,3 +20,5 @@
 //
 //= require moment
 //= require moment/es
+
+//= require filter_table

--- a/app/assets/javascripts/filter_table.js
+++ b/app/assets/javascripts/filter_table.js
@@ -1,0 +1,30 @@
+(function( $ ) {
+  $.fn.filterable = function(options) {
+    var defaults = {
+      inputSelector: '.filterer',
+      hasHeaderRow: true
+    };
+    var settings = $.extend( {}, defaults, options );
+    var $input = $(settings.inputSelector);
+    var $rows = this.find('tr');
+
+    if (settings.hasHeaderRow) {
+      $rows = $rows.not(':first');
+    }
+
+    _bindFilterEvent($input, $rows);
+
+    return this;
+  };
+
+  function _bindFilterEvent($input, $rows) {
+    $input.on('keyup', function() {
+      var val = $.trim($(this).val()).replace(/ +/g, ' ').toLowerCase();
+
+      $rows.show().filter(function() {
+          var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
+          return !~text.indexOf(val);
+      }).hide();
+    });
+  };
+})( jQuery );

--- a/app/views/associables/partials/_objectives.html.erb
+++ b/app/views/associables/partials/_objectives.html.erb
@@ -2,13 +2,20 @@
 
 <div class="tab-pane active" id="table" role="tabpanel" aria-expanded="false">
   <div class="input-group padding-10 inline" style="width: 80%; overflow: auto">
-    <%= text_field :search, :input, placeholder: 'Buscar', class: 'form-control'%>
+    <%=
+      text_field(
+        :search,
+        :input,
+        placeholder: 'Buscar',
+        class: 'form-control filterer'
+      )
+    %>
     <span class="input-group-addon">
       <i class="icmn-search"></i>
     </span>
   </div>
   <div class="table-responsive" style="height:301px; overflow:auto; width: auto">
-    <table class="table table-hover">
+    <table class="table table-hover filterable">
       <thead>
       <tr>
         <th>Nombre</th>
@@ -68,4 +75,5 @@
         }
     });
 
+  $('.filterable').filterable();
 </script>

--- a/app/views/associables/partials/_objectives.html.erb
+++ b/app/views/associables/partials/_objectives.html.erb
@@ -10,9 +10,6 @@
         class: 'form-control filterer'
       )
     %>
-    <span class="input-group-addon">
-      <i class="icmn-search"></i>
-    </span>
   </div>
   <div class="table-responsive" style="height:301px; overflow:auto; width: auto">
     <table class="table table-hover filterable">


### PR DESCRIPTION
**Why is this change necessary?**
We want to be able to filter the table displayed on ./analisis/indicadores/nuevo

**How does this accomplish the change?**
Added simple jQuery plugin that can be called on any table which accepts an input to listen to and hides the rows that do not match entered text in the input


![feb-21-2017 22-55-32](https://cloud.githubusercontent.com/assets/3662050/23196644/f38d2630-f888-11e6-8f15-3a8b86a8266d.gif)
